### PR TITLE
Browser des caches APC de squelettes SPIP

### DIFF
--- a/apc.php
+++ b/apc.php
@@ -1,4 +1,4 @@
-<?php
+	<?php
 /*
   +----------------------------------------------------------------------+
   | APC                                                                  |
@@ -237,8 +237,8 @@ $vardom=array(
 	'AGGR'	=> '/^\d+$/',			// aggregation by dir level
 	'SEARCH'	=> '~^[a-zA-Z0-9/_.-]*$~',			// aggregation by dir level
 	'TYPECACHE' => '/^(ALL|SESSIONS|SESSIONS_AUTH)$/',	//
-	'ZOOM' => '/^(TEXTECOURT|TEXTELONG)$/',	//
-	'EXTRA' => '/^(CONTEXTE|CONTEXTE_SPECIAUX|INVALIDEURS|INVALIDEURS_SPECIAUX)$/',	//
+	'ZOOM' => '/^(|TEXTECOURT|TEXTELONG)$/',	//
+	'EXTRA' => '/^(|CONTEXTE|CONTEXTE_SPECIAUX|INVALIDEURS|INVALIDEURS_SPECIAUX)$/',	//
 );
 
 // cache scope
@@ -262,11 +262,12 @@ if (empty($_REQUEST)) {
 
 // check parameter syntax
 foreach($vardom as $var => $dom) {
-	if (!isset($_REQUEST[$var])) {
+	if (!isset($_REQUEST[$var]))
 		$MYREQUEST[$var]=NULL;
-	} else if (!is_array($_REQUEST[$var]) && preg_match($dom.'D',$_REQUEST[$var])) {
+	else if (!is_array($_REQUEST[$var]) && preg_match($dom.'D',$_REQUEST[$var]))
 		$MYREQUEST[$var]=$_REQUEST[$var];
-	} else {
+	else {
+		echo "<xmp>ERREUR avec parametre d'url « $var » qui vaut « {$_REQUEST[$var]} »</xmp>";
 		$MYREQUEST[$var]=$_REQUEST[$var]=NULL;
 	}
 }
@@ -284,7 +285,10 @@ $MY_SELF=
 	"?SCOPE=".$MYREQUEST['SCOPE'].
 	"&SORT1=".$MYREQUEST['SORT1'].
 	"&SORT2=".$MYREQUEST['SORT2'].
-	"&COUNT=".$MYREQUEST['COUNT'];
+	"&COUNT=".$MYREQUEST['COUNT'].
+	"&SEARCH=".$MYREQUEST['SEARCH']; // AJOUTÉ
+echo "<H1>MY_SELF=$MY_SELF</H1>";
+
 $MY_SELF_WO_SORT=
 	"$PHP_SELF".
 	"?SCOPE=".$MYREQUEST['SCOPE'].
@@ -1214,7 +1218,7 @@ EOB;
         echo
           '<tr id="key-'. $sh .'" class=tr-',$i%2,'>',
           "<td class=td-0>
-			<a href=\"$MY_SELF&OB=",$MYREQUEST['OB'],"&SH={$sh}&TYPECACHE={$TYPECACHE}&ZOOM={$MYREQUEST['ZOOM']}&EXTRA={$MYREQUEST['EXTRA']}#key-{$sh}\">",$field_value,'</a>';
+			<a href=\"$MY_SELF&OB={$MYREQUEST['OB']}&SH={$sh}&TYPECACHE={$TYPECACHE}&ZOOM={$MYREQUEST['ZOOM']}&EXTRA={$MYREQUEST['EXTRA']}#key-{$sh}\">",$field_value,'</a>';
 			if ($MYREQUEST['EXTRA'] 
 					and apcu_exists($entry['info'])
 					and ($data = apcu_fetch($entry['info'], $success))

--- a/apc.php
+++ b/apc.php
@@ -1,4 +1,4 @@
-	<?php
+<?php
 /*
   +----------------------------------------------------------------------+
   | APC                                                                  |
@@ -1067,7 +1067,7 @@ case OB_USER_CACHE:
 
 	$cols=6;
 	echo <<<EOB
-		<div class=sorting><form>Scope:
+		<div class=sorting><form>Scope: 
 		<input type=hidden name=OB value={$MYREQUEST['OB']}>
 		<select name=SCOPE>
 EOB;
@@ -1076,7 +1076,7 @@ EOB;
 		"<option value=D",$MYREQUEST['SCOPE']=='D' ? " selected":"",">Deleted</option>",
 		"</select>",
 		
-		", Sorting:<select name=SORT1>",
+		" Sorting:<select name=SORT1>",
 		"<option value=H",$MYREQUEST['SORT1']=='H' ? " selected":"",">Hits</option>",
 		"<option value=Z",$MYREQUEST['SORT1']=='Z' ? " selected":"",">Size</option>",
 		"<option value=S",$MYREQUEST['SORT1']=='S' ? " selected":"",">$fieldheading</option>",
@@ -1108,20 +1108,20 @@ EOB;
 		'&nbsp;<input type=submit value="GO!">',
 		
 		'<br>',
-		'Type caches',
+		'Type caches: ',
 		'<select name=TYPECACHE  onChange="form.submit()">',
 		'<option value=ALL',$MYREQUEST['TYPECACHE']=='ALL' ? ' selected':'','>Tous</option>',
 		'<option value=SESSIONS',$MYREQUEST['TYPECACHE']=='SESSIONS' ? ' selected':'','>Sessionnés</option>',
 		'<option value=SESSIONS_AUTH',$MYREQUEST['TYPECACHE']=='SESSIONS_AUTH' ? ' selected':'','>Sessionnés identifiés</option>',
 		'</select>',
 
-		'Textes zooms',
+		'&nbsp;&nbsp;Textes zooms: ',
 		'<select name=ZOOM  onChange="form.submit()">',
 		'<option value=TEXTECOURT',$MYREQUEST['ZOOM']=='TEXTECOURT' ? ' selected':'','>Courts</option>',
 		'<option value=TEXTELONG',$MYREQUEST['ZOOM']=='TEXTELONG' ? ' selected':'','>Entiers</option>',
 		'</select>',
 
-		'Affichage extra',
+		'&nbsp;&nbsp;Affichage extra: ',
 		'<select name=EXTRA  onChange="form.submit()">',
 		'<option value="" ',$MYREQUEST['EXTRA']=='' ? ' selected':'','></option>',
 		'<option value=CONTEXTE ',$MYREQUEST['EXTRA']=='CONTEXTE' ? ' selected':'','>Contexte</option>',
@@ -1221,24 +1221,37 @@ EOB;
 					and $success and is_array($data) and (count ($data)==1) 
 					and is_serialized($data[0])) {
 				$data = unserialize($data[0]);
-				switch ($MYREQUEST['EXTRA']) {
-				case 'CONTEXTE' :
-					$extra = $data['contexte'];
-					break;
-				case 'CONTEXTE_SPECIAUX' :
-					$extra = $data['contexte'];
-					foreach (array ('lang', 'date', 'date_default', 'date_redac', 'date_redac_default') as $k)
-						unset($extra[$k]);
-					break;
-				case 'INVALIDEURS' :
-					$extra = $data['invalideurs'];
-					break;
-				case 'INVALIDEURS_SPECIAUX' :
-					$extra = $data['invalideurs'];
-					foreach (array ('cache', 'session') as $k)
-						unset($extra[$k]);
-					break;
+				if (is_array($data)) {
+					switch ($MYREQUEST['EXTRA']) {
+					case 'CONTEXTE' :
+						if (isset($data['contexte']))
+							$extra = $data['contexte'];
+						else 
+							$extra = 'undefined';
+						break;
+					case 'CONTEXTE_SPECIAUX' :
+						if (isset($data['contexte'])) {
+							$extra = $data['contexte'];
+							foreach (array ('lang', 'date', 'date_default', 'date_redac', 'date_redac_default') as $k)
+								unset($extra[$k]);
+						}
+						else 
+							$extra = 'undefined';
+						break;
+					case 'INVALIDEURS' :
+						$extra = $data['invalideurs'];
+						break;
+					case 'INVALIDEURS_SPECIAUX' :
+						$extra = $data['invalideurs'];
+						foreach (array ('cache', 'session') as $k)
+							unset($extra[$k]);
+						break;
+					}
 				}
+				else
+					$extra = null;
+				if ($extra == 'undefined')
+					$extra = array ('contexte non défini' => 'vrai');
 				if ($extra = print_array_content($extra, 1))
 					echo "<br><xmp>    $extra</xmp>";
 			};

--- a/apc.php
+++ b/apc.php
@@ -236,7 +236,7 @@ $vardom=array(
 	'SORT2'	=> '/^[DA]$/',			// second sort key
 	'AGGR'	=> '/^\d+$/',			// aggregation by dir level
 	'SEARCH'	=> '~^[a-zA-Z0-9/_.-]*$~',			// aggregation by dir level
-	'TYPECACHE' => '/^(ALL|SESSIONS|SESSIONS_AUTH)$/',	//
+	'TYPECACHE' => '/^(ALL|SESSIONS|SESSIONS_AUTH|FORMULAIRES)$/',	//
 	'ZOOM' => '/^(|TEXTECOURT|TEXTELONG)$/',	//
 	'EXTRA' => '/^(|CONTEXTE|CONTEXTE_SPECIAUX|INVALIDEURS|INVALIDEURS_SPECIAUX)$/',	//
 );
@@ -1117,6 +1117,7 @@ EOB;
 		'<option value=ALL',$MYREQUEST['TYPECACHE']=='ALL' ? ' selected':'','>Tous</option>',
 		'<option value=SESSIONS',$MYREQUEST['TYPECACHE']=='SESSIONS' ? ' selected':'','>Sessionnés</option>',
 		'<option value=SESSIONS_AUTH',$MYREQUEST['TYPECACHE']=='SESSIONS_AUTH' ? ' selected':'','>Sessionnés identifiés</option>',
+		'<option value=FORMULAIRES',$MYREQUEST['TYPECACHE']=='FORMULAIRES' ? ' selected':'','>Formulaires</option>',
 		'</select>',
 
 		'&nbsp;&nbsp;Textes zooms: ',
@@ -1204,6 +1205,9 @@ EOB;
 			case 'SESSIONS_AUTH' :
 				$pattern_typecache = '/_[a-f0-9]{8}$/i';
 				break;
+			case 'FORMULAIRES' :
+				$pattern_typecache = '~formulaires/~i';
+				break;
 		};
 
 		// output list
@@ -1220,6 +1224,7 @@ EOB;
           "<td class=td-0>
 			<a href=\"$MY_SELF&OB={$MYREQUEST['OB']}&SH={$sh}&TYPECACHE={$TYPECACHE}&ZOOM={$MYREQUEST['ZOOM']}&EXTRA={$MYREQUEST['EXTRA']}#key-{$sh}\">",$field_value,'</a>';
 			if ($MYREQUEST['EXTRA'] 
+					and ($sh != $MYREQUEST["SH"]) // sinon yaura un zoom après et c'est inutile de répéter ici
 					and apcu_exists($entry['info'])
 					and ($data = apcu_fetch($entry['info'], $success))
 					and $success and is_array($data) and (count ($data)==1) 


### PR DESCRIPTION
- les caches sérialisés sont désérialisés pour une lecture facilitée. Les textwheel sont laissées intactes.
- option "texte court" pour lire plus facilement les métadonnées et les variables de contexte (plutôt que le HTML du squelette)
- menu pour choisir de voir 1) tous les caches 2) seulement les caches de squelettes sessionnés 3) seulement les caches de squelettes sessionnés avec un visiteur identifié